### PR TITLE
TypeSwitch -> std::conditional

### DIFF
--- a/FixedWidthField.hpp.in
+++ b/FixedWidthField.hpp.in
@@ -1,7 +1,5 @@
 #include <type_traits>
 
-#include "utility/TypeSwitch.hpp"
-
 namespace disco{
 
 template< uint16_t w >
@@ -14,15 +12,12 @@ struct FixedWidthField {
   /* convenience typedefs */
   template< typename T >
   using ArgumentType =
-    typename utility::TypeSwitch
-             < T, typename std::add_const
-                           < typename std::add_lvalue_reference
-                                      < T >::type >::type,
-               std::is_trivially_copyable< T >::value >::type;
+    std::conditional_t
+    < std::is_trivially_copyable< T >::value,
+      T, std::add_const_t < std::add_lvalue_reference_t< T > > >;
 
   template< bool trust >
-  using TrustTag = typename utility::TypeSwitch
-                            < Trusted, NotTrusted, trust >::type;
+  using TrustTag = std::conditional_t< trust, Trusted, NotTrusted >;
 
   /* helper methods */
   template< typename Iterator >
@@ -36,19 +31,13 @@ struct FixedWidthField {
   }
   
   constexpr static bool
-  isSpace( const char c ){
-    return c == ' ' || c == '\t';
-  }
+  isSpace( const char c ){ return c == ' ' || c == '\t'; }
 
   constexpr static bool
-  isNewline( const char c ){
-    return c == '\n' || c == '\f' || c == '\r';
-  }
+  isNewline( const char c ){ return c == '\n' || c == '\f' || c == '\r'; }
 
   constexpr static bool
-  isEOF( const char c ){
-    return c == std::char_traits<char>::eof();
-  }
+  isEOF( const char c ){ return c == std::char_traits<char>::eof(); }
 
 #include "disco/FixedWidthField/src/skipPad.hpp"
   

--- a/FixedWidthField/Integer.hpp.in
+++ b/FixedWidthField/Integer.hpp.in
@@ -15,9 +15,8 @@ struct Integer : public FixedWidthField< w >{
   struct WithoutPadding{};
 
   using ZeroPaddingPolicy =
-    typename utility::TypeSwitch
-             < WithoutPadding, WithPadding,
-               m == std::numeric_limits<uint16_t>::max() >::type;
+    std::conditional_t< m == std::numeric_limits<uint16_t>::max(),
+                        WithoutPadding, WithPadding >;
   
   /* methods */
 #include "disco/FixedWidthField/Integer/src/read.hpp"

--- a/FixedWidthField/Integer/src/read.hpp.in
+++ b/FixedWidthField/Integer/src/read.hpp.in
@@ -1,9 +1,9 @@
 template< typename T, typename Iterator, bool trust = true >
 static T
 read( Iterator& it, const Iterator& end ){
-  using Signedness = typename utility::TypeSwitch
-                                       < Signed, Unsigned,
-                                         std::is_signed< T >::value >::type;
+  using Signedness =
+    std::conditional_t< std::is_signed< T >::value, Signed, Unsigned >;
+  
   FixedWidthField_::verifyWidth_( it, end, TrustTag< trust >() );
   auto position = FixedWidthField_::skipPad( it );
 

--- a/FixedWidthField/Real/ENDF.hpp.in
+++ b/FixedWidthField/Real/ENDF.hpp.in
@@ -3,7 +3,7 @@ namespace disco {
 struct ENDF : public Real< 11 > {
 
   static constexpr int w = 11;
-  using Real_ = Real< w >;
+  using Real_t = Real< w >;
 
   static constexpr double maxValue = 1E39;
   static constexpr double minValue = 1E-38;

--- a/FixedWidthField/Real/FixedPoint.hpp.in
+++ b/FixedWidthField/Real/FixedPoint.hpp.in
@@ -3,7 +3,7 @@ namespace disco {
 template< uint16_t w, uint16_t d >
 struct FixedPoint : public Real< w > {
 
-  using Real_ = Real< w >;
+  using Real_t = Real< w >;
 
   static constexpr int64_t maxPositiveValue =
     integerExponentiation< int64_t >::cache( int(w) - d - 1 );
@@ -12,11 +12,13 @@ struct FixedPoint : public Real< w > {
     -1 * integerExponentiation< int64_t >::cache( int(w) - d - 2 );
   
   using InfinityPrintingPolicy =
-    typename utility::TypeSwitch
-             < typename Real_::Full, typename utility::TypeSwitch
-               < typename Real_::Partial, typename Real_::PartialNegative,
-                 ( w < 8 ) >::type, ( w > 8 ) >::type;
-  
+    std::conditional_t
+    < ( w > 8 ),
+      typename Real_t::Full,
+      std::conditional_t< ( w < 8 ),
+                          typename Real_t::Partial,
+                          typename Real_t::PartialNegative > >;
+                 
   template< typename Representation >
   static bool
   isInvalid( Representation real ){

--- a/FixedWidthField/Real/Scientific.hpp.in
+++ b/FixedWidthField/Real/Scientific.hpp.in
@@ -3,20 +3,22 @@ namespace disco {
 template< uint16_t w, uint16_t d, uint16_t e >
 struct Scientific : public Real< w > {
 
-  using Real_ = Real< w >;
-  using MayConsumeExponent = typename Real_::MayConsumeExponent;
-  using MayNotConsumeExponent = typename Real_::MayNotConsumeExponent;
+  using Real_t = Real< w >;
+  using MayConsumeExponent = typename Real_t::MayConsumeExponent;
+  using MayNotConsumeExponent = typename Real_t::MayNotConsumeExponent;
 
   using InfinityPrintingPolicy =
-    typename utility::TypeSwitch
-             < typename Real_::Full, typename utility::TypeSwitch
-               < typename Real_::Partial, typename Real_::PartialNegative,
-                 ( w < 8 ) >::type, ( w > 8 ) >::type;
+    std::conditional_t
+    < (w > 8 ),
+      typename Real_t::Full,
+      std::conditional_t
+      < ( w < 8 ),
+        typename Real_t::Partial,
+        typename Real_t::PartialNegative > >;
   
   using ExponentPolicy =
-    typename utility::TypeSwitch
-             < MayConsumeExponent, MayNotConsumeExponent,
-               e == std::numeric_limits< uint16_t >::max() >::type;
+    std::conditional_t< e == std::numeric_limits< uint16_t >::max(),
+                        MayConsumeExponent, MayNotConsumeExponent >;
 
   static constexpr int exponentDigits =
     ( e == std::numeric_limits< uint16_t >::max() ) ? 2 : e;
@@ -33,7 +35,7 @@ struct Scientific : public Real< w > {
     return ( int(w) - d - exponentDigits - 4 - ( real < 0 ) ) < 0;
   }
 
-  using Real_::write;
+  using Real_t::write;
   
 #include "disco/FixedWidthField/Real/Scientific/src/write.hpp" 
 #include "disco/FixedWidthField/Real/Scientific/src/writeWithoutConsumption.hpp" 

--- a/FixedWidthField/Real/Scientific/src/write.hpp.in
+++ b/FixedWidthField/Real/Scientific/src/write.hpp.in
@@ -20,7 +20,7 @@ template< typename Representation, typename Iterator >
 static void
 write( Representation real, Iterator& it, MayNotConsumeExponent ){
   const int requiredDigits =
-    Real_::noDigits( std::ceil( std::abs( std::log10( std::abs( real ) ) ) ) );
+    Real_t::noDigits( std::ceil( std::abs( std::log10( std::abs( real ) ) ) ) );
   ( requiredDigits <= exponentDigits ) ? 
     writeWithoutConsumption( real, it, requiredDigits ) :
     writeInvalid( it );
@@ -30,7 +30,7 @@ template< typename Representation, typename Iterator >
 static void
 write( Representation real, Iterator& it, MayConsumeExponent ){
   const int requiredDigits =
-    Real_::noDigits( std::ceil( std::abs( std::log10( std::abs( real ) ) ) ) );
+    Real_t::noDigits( std::ceil( std::abs( std::log10( std::abs( real ) ) ) ) );
   ( requiredDigits <= exponentDigits ) ? 
     writeWithoutConsumption( real, it, requiredDigits ) :
     ( requiredDigits <= ( exponentDigits + 1 ) ) ?

--- a/FixedWidthField/Real/Scientific/src/writeInfinity.hpp.in
+++ b/FixedWidthField/Real/Scientific/src/writeInfinity.hpp.in
@@ -1,6 +1,6 @@
 template< typename Iterator >
 static void
-writeInfinity( Iterator& it, bool isNegative, typename Real_::Full ){
+writeInfinity( Iterator& it, bool isNegative, typename Real_t::Full ){
   auto remainingBlanks = w - 8;
   while ( --remainingBlanks > 0 ){
     *it++ = ' ';
@@ -22,7 +22,7 @@ writeInfinity( Iterator& it, bool isNegative, typename Real_::Full ){
 
 template< typename Iterator >
 static void
-writeInfinity( Iterator& it, bool isNegative, typename Real_::Partial ){
+writeInfinity( Iterator& it, bool isNegative, typename Real_t::Partial ){
   auto remainingBlanks = int(w) - 3;
   if (  (remainingBlanks - isNegative) < 0 ){
     writeInvalid( it );
@@ -44,8 +44,8 @@ writeInfinity( Iterator& it, bool isNegative, typename Real_::Partial ){
 template< typename Iterator >
 static void
 writeInfinity
-( Iterator& it, bool isNegative, typename Real_::PartialNegative ){
+( Iterator& it, bool isNegative, typename Real_t::PartialNegative ){
   isNegative ?
-    writeInfinity( it, isNegative, typename Real_::Partial() ) :
-    writeInfinity( it, isNegative, typename Real_::Full() );
+    writeInfinity( it, isNegative, typename Real_t::Partial() ) :
+    writeInfinity( it, isNegative, typename Real_t::Full() );
 }


### PR DESCRIPTION
Originally written in terms of the utility library TypeSwitch metaprogram due to ignorance of the std::conditional metaprogram of the type_traits header. Rewritten to use the standard library template.

Other minor changes:
+ Real_ -> Real_t