### PR TITLE
Cast an int64_t to uint64_t for a comparison.

### DIFF
--- a/src/disco/FixedWidthField/Integer/src/parseInteger.hpp
+++ b/src/disco/FixedWidthField/Integer/src/parseInteger.hpp
@@ -32,7 +32,7 @@ parseInteger( Iterator& it, uint16_t& position, Signed ){
 
   const auto magnitude = parseInteger( it, position, Unsigned() );
 
-  if ( unlikely( magnitude > (uint64_t) std::numeric_limits< int64_t >::max() ) ){
+  if ( unlikely( magnitude > static_cast<uint64_t>( std::numeric_limits< int64_t >::max() ) ) ){
     throw std::runtime_error( "Value overflowed during integer read" );
   }
 

--- a/src/disco/FixedWidthField/Integer/src/parseInteger.hpp
+++ b/src/disco/FixedWidthField/Integer/src/parseInteger.hpp
@@ -32,7 +32,7 @@ parseInteger( Iterator& it, uint16_t& position, Signed ){
 
   const auto magnitude = parseInteger( it, position, Unsigned() );
 
-  if ( unlikely( magnitude > std::numeric_limits< int64_t >::max() ) ){
+  if ( unlikely( magnitude > (uint64_t) std::numeric_limits< int64_t >::max() ) ){
     throw std::runtime_error( "Value overflowed during integer read" );
   }
 


### PR DESCRIPTION
Simple change to avoid a warning generated due to a signed integer being compared to an unsigned integer.  The signed integer is guaranteed to be positive, so this should not lead to any odd behavior.  Test suite passes.  The `directory` project compiles on GCC 9.2 with this change.